### PR TITLE
bump runtime version to node16

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+# NOTE:
+
+This fork uses hard coded node versions.
+The node version running inside the container (which invokes the actual function code) is still node 10.
+The node version that runs on lambda (which triggers container invokation) is node 16.
+
+Having the container running on node 10 is due to the fact that the upstream repository providing the container image is not longer maintained.
+There is a fork which also has newer node versions (https://github.com/mLupine/docker-lambda) but we currently lack the time to incoorporate that.
+
 # Serverless Batch
 [![serverless](http://public.serverless.com/badges/v3.svg)](http://www.serverless.com)
 

--- a/lib/batchtask.js
+++ b/lib/batchtask.js
@@ -77,7 +77,7 @@ function compileBatchTask(functionName) {
           name: functionObject.name,
           memorySize: 128,
           timeout: 6,
-          runtime: 'nodejs10.x',
+          runtime: 'nodejs16.x',
           package: {
             artifact: `${path.join(this.serverless.config.servicePath, '.serverless', functionName)}.zip`
           },

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -78,14 +78,14 @@ function buildDockerImage() {
     //   - Function Timeout and Function Memory are set by Env Variables on the Job Definition
     //   - Access Key and Secret are unset to that we use the role on the container that AWS provides
     const dockerFileContents = `
-    FROM justinram11/lambda:build-nodejs12.x AS builder
+    FROM justinram11/lambda:build-nodejs10.x AS builder
     USER root
     
     ${additionalRunCommands}
     COPY ${this.serverless.service.service}.zip /tmp
     RUN cd /tmp && unzip -q ${this.serverless.service.service}.zip && rm ${this.serverless.service.service}.zip
     
-    FROM justinram11/lambda:nodejs12.x
+    FROM justinram11/lambda:nodejs10.x
     COPY --from=builder /tmp /var/task/${this.serverless.service.service}/
     RUN rm -rf /tmp/*
     ENV NODE_OPTIONS="--max-old-space-size=30000"\n

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -78,24 +78,19 @@ function buildDockerImage() {
     //   - Function Timeout and Function Memory are set by Env Variables on the Job Definition
     //   - Access Key and Secret are unset to that we use the role on the container that AWS provides
     const dockerFileContents = `
-    FROM justinram11/lambda:build-${this.serverless.service.provider.runtime} AS builder
+    FROM justinram11/lambda:build-nodejs12.x AS builder
     USER root
     
     ${additionalRunCommands}
     COPY ${this.serverless.service.service}.zip /tmp
     RUN cd /tmp && unzip -q ${this.serverless.service.service}.zip && rm ${this.serverless.service.service}.zip
     
-    FROM justinram11/lambda:${this.serverless.service.provider.runtime}
+    FROM justinram11/lambda:nodejs12.x
     COPY --from=builder /tmp /var/task/${this.serverless.service.service}/
     RUN rm -rf /tmp/*
+    ENV NODE_OPTIONS="--max-old-space-size=30000"\n
     `;
-    // custom ENTRYPOINT due to heap setting - entrypoint copied from original
-    if (this.serverless.service.provider.runtime === 'nodejs8.10') dockerFileContents.concat(
-        'ENTRYPOINT ["/var/lang/bin/node", "--expose-gc", "--max-semi-space-size=150", "--max-old-space-size=30000", "/var/runtime/node_modules/awslambda/index.js"]\n'
-    );
-    if (this.serverless.service.provider.runtime === 'nodejs10.x') dockerFileContents.concat(
-        'ENV NODE_OPTIONS="--max-old-space-size=30000"\n'
-    );
+
     const servicePath = this.serverless.config.servicePath || '';
     const packagePath = path.join(servicePath || '.', '.serverless');
     const dockerFile = path.join(packagePath, 'Dockerfile');

--- a/lib/docker.js
+++ b/lib/docker.js
@@ -51,8 +51,15 @@ function dockerCommand(options, cwd = null, stdio = null) {
  * https://hub.docker.com/r/lambci/lambda/
  */
 function buildDockerImage() {
+    if(!this.serverless.service.getAllFunctions().length) {
+        this.serverless.cli.log(`No functions defined, skipping docker image build...`);   
+        return BbPromise.resolve(); 
+    } else {
+        this.serverless.cli.log(`Functions found`);
+    }
+    
     this.serverless.cli.log(`Building docker image: "${this.provider.naming.getDockerImageName()}"...`);
-
+    
     // Get any additional run commands we'd like to include in the docker image
     let additionalRunCommands = "";
     if (this.serverless.service.custom


### PR DESCRIPTION
This is basically the same thing sander already introduced.
It also bumps the runtime that the lambda functions use (to trigger the container execution) to node 16.

**NOTE: ** When this gets merged into master, the new commit hash should be provided for the PR https://github.com/studentathome/StudentAanHuisCORELAMBDA/pull/390 before it gets merged.